### PR TITLE
Add Mattermost formatter, test file, and config update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,40 @@
 # paperbee
 
 paperbee
+
+## Mattermost Integration
+
+Paperbee can now send formatted paper lists to a Mattermost channel.
+
+### Configuration
+
+Add the following section to your `config.yml` (see also `files/config_template.yml`):
+
+```yaml
+MATTERMOST:
+  is_posting_on: true
+  url: "your-mattermost-url"           # e.g. mattermost.example.com
+  token: "your-mattermost-access-token"
+  team: "your-mattermost-team-name"
+  channel: "your-mattermost-channel-name"
+```
+
+Alternatively, you can set the following environment variables:
+- `MATTERMOST_URL`
+- `MATTERMOST_TOKEN`
+- `MATTERMOST_TEAM`
+- `MATTERMOST_CHANNEL`
+
+### Sending Papers to Mattermost
+
+1. Install the required dependency:
+   ```bash
+   poetry add python-mattermost-driver
+   ```
+2. Set your Mattermost credentials as environment variables (see above).
+3. Run the script:
+   ```bash
+   python src/send_to_mattermost.py
+   ```
+
+The script will format a sample list of papers and post it to your specified Mattermost channel.

--- a/files/config_template.yml
+++ b/files/config_template.yml
@@ -41,6 +41,14 @@ ZULIP:
   stream: "your-zulip-stream"
   topic: "your-zulip-topic"
 
+# Mattermost configuration
+MATTERMOST:
+  is_posting_on: true                # Set to true to enable Mattermost posting
+  url: "your-mattermost-url"        # e.g. mattermost.example.com
+  token: "your-mattermost-access-token" # Your Mattermost personal access token
+  team: "your-mattermost-team-name" # The team name (not display name)
+  channel: "your-mattermost-channel-name" # The channel name (not display name)
+
 
 
 

--- a/src/PaperBee/papers/mattermost_papers_formatter.py
+++ b/src/PaperBee/papers/mattermost_papers_formatter.py
@@ -1,0 +1,100 @@
+from logging import Logger
+from typing import List, Optional, Tuple
+
+class MattermostPaperPublisher:
+    """
+    A class to format academic papers for Mattermost channels.
+
+    Args:
+        logger (Logger): A logger instance for logging information and errors.
+        channel_id (str): The Mattermost channel ID where papers will be published.
+    """
+
+    def __init__(
+        self,
+        logger: Logger,
+        channel_id: Optional[str] = None,
+    ) -> None:
+        """
+        Initializes the MattermostPaperPublisher with the logger and channel ID.
+
+        Args:
+            logger (Logger): The logger instance for logging messages.
+            channel_id (str): The Mattermost channel ID. Defaults to None.
+        """
+        self.logger = logger
+        if channel_id:
+            self.channel_id = channel_id
+        else:
+            e = "Channel ID is required to publish papers to Mattermost."
+            raise ValueError(e)
+
+    @staticmethod
+    def format_papers(
+        papers_list: List[List[str]],
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Formats a list of papers into separate lists for regular papers and preprints for Mattermost.
+
+        Args:
+            papers_list (List[List[str]]): A list of papers, where each paper is a list of Args.
+
+        Returns:
+            Tuple[List[str], List[str]]: Two lists, one for regular papers and one for preprints, each formatted for Mattermost.
+        """
+        papers = []
+        preprints = []
+        for paper in papers_list:
+            emoji = "✏️" if paper[3] == "TRUE" else "🗞️"
+            title = paper[4]
+            link = paper[-1]
+            formatted_paper = f"{emoji} [{title}]({link})"
+
+            if paper[3] == "TRUE":
+                preprints.append(formatted_paper)
+            else:
+                papers.append(formatted_paper)
+
+        return papers, preprints
+
+    def build_message(
+        self,
+        papers: List[str],
+        preprints: List[str],
+        today: str,
+        spreadsheet_id: str,
+    ) -> str:
+        """
+        Builds the message to be sent to Mattermost channel.
+
+        Args:
+            papers (List[str]): A list of formatted regular papers.
+            preprints (List[str]): A list of formatted preprints.
+            today (str): The date for the publication (used in the header).
+            spreadsheet_id (str): The ID of the Google Spreadsheet containing the papers.
+
+        Returns:
+            str: The complete message to send to Mattermost.
+        """
+        divider = "────────────"
+        header = f"Good morning :coffee: Here are today's papers!\n"
+        footer = "\nEnjoy your reading! :wave:\n"
+        message_blocks = [header, "**Preprints:** :point_down:"]
+
+        if len(preprints) > 0:
+            message_blocks.extend(preprints)
+        else:
+            message_blocks.append("No preprints found today.")
+
+        message_blocks.append(divider)
+        message_blocks.append("\n**Papers:** :point_down:")
+
+        if len(papers) > 0:
+            message_blocks.extend(papers)
+        else:
+            message_blocks.append("No papers found today.")
+
+        message_blocks.append(divider)
+        message_blocks.append(footer)
+
+        return "\n".join(message_blocks) 

--- a/src/demo_mattermost.py
+++ b/src/demo_mattermost.py
@@ -1,0 +1,76 @@
+import os
+from logging import Logger
+from PaperBee.papers.mattermost_papers_formatter import MattermostPaperPublisher
+from mattermostdriver import Driver
+
+# Usage: Set MATTERMOST_URL, MATTERMOST_TOKEN, MATTERMOST_TEAM, MATTERMOST_CHANNEL env vars before running.
+
+# Sample paper data (from tests/test_telegram.py)
+papers_data = [
+    [
+        "10.1101/2024.04.26.591400",
+        "2024-04-29",
+        "2024-04-28",
+        "TRUE",
+        "Single-Cell Transcriptomics Reveals the Molecular Logic Underlying Ca2+ Signaling Diversity in Human and Mouse Brain",
+        "https://doi.org/10.1101/2024.04.26.591400",
+    ],
+    [
+        "10.1101/2024.04.22.590645",
+        "2024-04-29",
+        "2024-04-26",
+        "TRUE",
+        "scMUSCL: Multi-Source Transfer Learning for Clustering scRNA-seq Data",
+        "https://doi.org/10.1101/2024.04.22.590645",
+    ],
+    [
+        "10.1101/2024.04.21.590442",
+        "2024-04-29",
+        "2024-04-26",
+        "TRUE",
+        "Imbalance and Composition Correction Ensemble Learning Framework (ICCELF): A novel framework for automated scRNA-seq cell type annotation",
+        "https://doi.org/10.1101/2024.04.21.590442",
+    ],
+]
+
+def main():
+    logger = Logger("MattermostTest")
+    channel_name = os.environ.get("MATTERMOST_CHANNEL")
+    team_name = os.environ.get("MATTERMOST_TEAM")
+    url = os.environ.get("MATTERMOST_URL")
+    token = os.environ.get("MATTERMOST_TOKEN")
+
+    if not all([channel_name, team_name, url, token]):
+        raise ValueError("Please set MATTERMOST_URL, MATTERMOST_TOKEN, MATTERMOST_TEAM, MATTERMOST_CHANNEL environment variables.")
+
+    # Initialize Mattermost driver
+    driver = Driver({
+        'url': url,
+        'token': token,
+        'scheme': 'https',
+        'port': 443,
+        'verify': True,
+        'debug': False,
+    })
+    driver.login()
+
+    # Get team and channel IDs
+    team = driver.teams.get_team_by_name(team_name)
+    team_id = team['id']
+    channel = driver.channels.get_channel_by_name(team_id, channel_name)
+    channel_id = channel['id']
+
+    # Format message
+    publisher = MattermostPaperPublisher(logger=logger, channel_id=channel_id)
+    papers, preprints = publisher.format_papers(papers_data)
+    message = publisher.build_message(papers, preprints, today=None, spreadsheet_id=None)
+
+    # Send message
+    post = driver.posts.create_post({
+        'channel_id': channel_id,
+        'message': message
+    })
+    print(f"Message sent to Mattermost channel {channel_name}: {post['id']}")
+
+if __name__ == "__main__":
+    main() 

--- a/tests/test_mattermost.py
+++ b/tests/test_mattermost.py
@@ -1,0 +1,55 @@
+import pytest
+from logging import Logger
+from PaperBee.papers.mattermost_papers_formatter import MattermostPaperPublisher
+
+@pytest.fixture
+def papers():
+    return [
+        [
+            "10.1101/2024.04.26.591400",
+            "2024-04-29",
+            "2024-04-28",
+            "TRUE",
+            "Single-Cell Transcriptomics Reveals the Molecular Logic Underlying Ca2+ Signaling Diversity in Human and Mouse Brain",
+            "https://doi.org/10.1101/2024.04.26.591400",
+        ],
+        [
+            "10.1101/2024.04.22.590645",
+            "2024-04-29",
+            "2024-04-26",
+            "TRUE",
+            "scMUSCL: Multi-Source Transfer Learning for Clustering scRNA-seq Data",
+            "https://doi.org/10.1101/2024.04.22.590645",
+        ],
+        [
+            "10.1101/2024.04.21.590442",
+            "2024-04-29",
+            "2024-04-26",
+            "TRUE",
+            "Imbalance and Composition Correction Ensemble Learning Framework (ICCELF): A novel framework for automated scRNA-seq cell type annotation",
+            "https://doi.org/10.1101/2024.04.21.590442",
+        ],
+    ]
+
+@pytest.fixture
+def publisher():
+    return MattermostPaperPublisher(
+        logger=Logger("MattermostTest"),
+        channel_id="dummy_channel_id"
+    )
+
+def test_format_papers(publisher, papers):
+    papers_out, preprints_out = publisher.format_papers(papers)
+    assert isinstance(papers_out, list)
+    assert isinstance(preprints_out, list)
+    # All test data are preprints
+    assert len(preprints_out) == len(papers)
+    assert all("[" in p and "](" in p for p in preprints_out)
+
+def test_build_message(publisher, papers):
+    papers_out, preprints_out = publisher.format_papers(papers)
+    message = publisher.build_message(papers_out, preprints_out, today="2024-04-29", spreadsheet_id="dummy_id")
+    assert isinstance(message, str)
+    assert "Preprints" in message
+    assert "Papers" in message
+    assert "Good morning" in message 


### PR DESCRIPTION
Summary
This PR adds support for sending daily paper digests to Mattermost channels. The implementation mirrors the existing Telegram integration and introduces a clean formatter, a demo script, and supporting tests.

What’s Included
Mattermost Formatter

Introduced MattermostPaperPublisher class for formatting paper lists for Mattermost
(File: src/PaperBee/papers/mattermost_papers_formatter.py)

Demo Script

Example script to send a formatted paper list to a Mattermost channel using the official API driver
(File: src/mattermost_demo.py)

Unit Tests

Tests covering formatter logic and message structure
(File: tests/test_mattermost.py)

Documentation

Updated usage instructions in docs/index.md

Configuration Template

Added Mattermost section to files/config_template.yml

 How to Test
Set up credentials:
Define your Mattermost credentials via environment variables or in the config file.

Run the demo:
Execute mattermost_demo.py to post a sample message to your Mattermost channel.

Run unit tests:
Execute pytest tests/test_mattermost.py to verify formatter logic.